### PR TITLE
Support _repr_pretty_

### DIFF
--- a/prettyprinter/__init__.py
+++ b/prettyprinter/__init__.py
@@ -306,6 +306,7 @@ ALL_EXTRAS = frozenset([
     'attrs',
     'django',
     'ipython',
+    'ipython_repr_pretty',
     'python',
     'requests',
     'dataclasses',

--- a/prettyprinter/doctypes.py
+++ b/prettyprinter/doctypes.py
@@ -75,7 +75,7 @@ class Concat(Doc):
         return res
 
     def __repr__(self):
-        return "Concat({})".format(
+        return "Concat([{}])".format(
             ', '.join(repr(doc) for doc in self.docs)
         )
 

--- a/prettyprinter/extras/ipython.py
+++ b/prettyprinter/extras/ipython.py
@@ -1,8 +1,11 @@
 import os
 
 import IPython.lib.pretty
+from IPython.lib.pretty import RepresentationPrinter
 
 from .. import cpprint
+
+OriginalRepresentationPrinter = RepresentationPrinter
 
 
 def install():

--- a/prettyprinter/extras/ipython_repr_pretty.py
+++ b/prettyprinter/extras/ipython_repr_pretty.py
@@ -36,7 +36,9 @@ class CompatRepresentationPrinter(OriginalRepresentationPrinter):
     def __init__(self, *args, **kwargs):
         self._prettyprinter_ctx = kwargs.pop('prettyprinter_ctx')
         super().__init__(*args, **kwargs)
-        self.output = NoopStream()
+
+        # self.output should be assigned by the superclass
+        assert isinstance(self.output, NoopStream)
 
         self._pending_wrapper = identity
         self._docparts = []

--- a/prettyprinter/extras/ipython_repr_pretty.py
+++ b/prettyprinter/extras/ipython_repr_pretty.py
@@ -1,0 +1,122 @@
+from contextlib import contextmanager
+
+from .ipython import OriginalRepresentationPrinter
+from ..utils import (
+    compose,
+    identity,
+)
+from ..prettyprinter import (
+    register_pretty,
+    pretty_python_value,
+)
+from ..doc import (
+    HARDLINE,
+    concat,
+    contextual,
+    flat_choice,
+    group,
+    nest
+)
+
+
+def implements_repr_pretty(instance):
+    try:
+        method = instance._repr_pretty_
+    except AttributeError:
+        return False
+    return callable(method)
+
+
+class NoopStream:
+    def write(self, value):
+        pass
+
+
+class CompatRepresentationPrinter(OriginalRepresentationPrinter):
+    def __init__(self, *args, **kwargs):
+        self._prettyprinter_ctx = kwargs.pop('prettyprinter_ctx')
+        super().__init__(*args, **kwargs)
+        self.output = NoopStream()
+
+        self._pending_wrapper = identity
+        self._docparts = []
+
+    def text(self, obj):
+        super().text(obj)
+
+        self._docparts.append(obj)
+
+    def breakable(self, sep=' '):
+        super().breakable(sep)
+
+        self._docparts.append(
+            flat_choice(when_flat=sep, when_broken=HARDLINE)
+        )
+
+    def begin_group(self, indent=0, open=''):
+        super().begin_group(indent, open)
+
+        def wrapper(doc):
+            if indent:
+                doc = nest(indent, doc)
+            return group(doc)
+
+        self._pending_wrapper = compose(wrapper, self._pending_wrapper)
+
+    def end_group(self, dedent=0, close=''):
+        super().end_group(dedent, close)
+
+        # dedent is ignored; it is not supported to
+        # have different indentation when starting and
+        # ending the group.
+
+        doc = self._pending_wrapper(concat(self._docparts))
+
+        self._docparts = [doc]
+        self._pending_wrapper = identity
+
+    @contextmanager
+    def indent(self, indent):
+        """with statement support for indenting/dedenting."""
+        curr_docparts = self._docparts
+        self._docparts = []
+        self.indentation += indent
+        try:
+            yield
+        finally:
+            self.indentation -= indent
+            indented_docparts = self._docparts
+            self._docparts = curr_docparts
+            self._docparts.append(nest(indent, concat(indented_docparts)))
+
+    def pretty(self, obj):
+        self._docparts.append(
+            pretty_python_value(obj, self._prettyprinter_ctx)
+        )
+
+
+def wrap_repr_pretty(fn):
+    def wrapped(value, ctx):
+        def evaluator(indent, column, page_width, ribbon_width):
+            printer = CompatRepresentationPrinter(
+                NoopStream(),
+                max_width=page_width - column,
+                max_seq_length=ctx.max_seq_len,
+                prettyprinter_ctx=ctx
+            )
+
+            with printer.group():
+                fn(value, printer, cycle=False)
+
+            return concat(printer._docparts)
+        return contextual(evaluator)
+    return wrapped
+
+
+def pretty_repr_pretty(value, ctx):
+    unbound_repr_pretty = value._repr_pretty_.__func__
+    return wrap_repr_pretty(unbound_repr_pretty)(value, ctx)
+
+
+def install():
+    register_pretty(predicate=implements_repr_pretty)(pretty_repr_pretty)

--- a/prettyprinter/utils.py
+++ b/prettyprinter/utils.py
@@ -51,3 +51,20 @@ def get_terminal_width(default=79):
 
 def take(n, iterable):
     return islice(iterable, n)
+
+
+def compose(f, g):
+    if f is identity:
+        return g
+    if g is identity:
+        return f
+
+    def composed(x):
+        return f(g(x))
+
+    composed.__name__ = 'composed_{}_then_{}'.format(
+        g.__name__,
+        f.__name__
+    )
+
+    return composed

--- a/tests/test_ipython_repr_pretty.py
+++ b/tests/test_ipython_repr_pretty.py
@@ -1,0 +1,36 @@
+import pytest
+
+from prettyprinter import (
+    pformat,
+)
+import prettyprinter.extras.ipython_repr_pretty
+
+prettyprinter.extras.ipython_repr_pretty.install()
+
+
+def test_compat():
+    class MyClass:
+        def _repr_pretty_(self, p, cycle):
+            with p.group(0, '{', '}'):
+                with p.indent(4):
+                    p.breakable(sep='')
+                    p.text("'a': ")
+                    p.pretty(1)
+                    p.text(',')
+                    p.breakable(sep=' ')
+                    p.text("'b': ")
+                    p.pretty(2)
+                p.breakable(sep='')
+
+    result = pformat(MyClass())
+    expected = """{'a': 1, 'b': 2}"""
+    assert result == expected
+
+    result = pformat(MyClass(), width=12)
+    expected = """\
+{
+    'a': 1,
+    'b': 2
+}"""
+
+    assert result == expected


### PR DESCRIPTION
Work in progress, but seems to work quite well.

Setup:

```python
from prettyprinter import install_extras
install_extras(['ipython_repr_pretty'])
```

Example with `patsy` from #3 

<img width="978" alt="repr_pretty_patsy" src="https://user-images.githubusercontent.com/2487359/34472588-1e6ace4c-ef1a-11e7-8130-8fb3b293f054.png">
