### PR TITLE
Deferred printer registration

### DIFF
--- a/prettyprinter/__init__.py
+++ b/prettyprinter/__init__.py
@@ -423,7 +423,7 @@ def pretty_repr(instance):
     instance_type = type(instance)
     if not is_registered(
         instance_type,
-        check_subclasses=True,
+        check_superclasses=True,
         check_deferred=True,
         register_deferred=True
     ):

--- a/prettyprinter/__init__.py
+++ b/prettyprinter/__init__.py
@@ -421,11 +421,16 @@ def pretty_repr(instance):
     """
 
     instance_type = type(instance)
-    if not is_registered(instance_type, check_subclasses=True):
+    if not is_registered(
+        instance_type,
+        check_subclasses=True,
+        check_deferred=True,
+        register_deferred=True
+    ):
         warnings.warn(
             "pretty_repr is assigned as the __repr__ method of "
-            "'{}'. However, no pretty printer is registered for that type or "
-            "its subclasses. Falling back to the default "
+            "'{}'. However, no pretty printer is registered for that type, "
+            "its superclasses or its subclasses. Falling back to the default "
             "repr implementation. To fix this warning, register a pretty "
             "printer using prettyprinter.register_pretty.".format(
                 instance_type.__qualname__

--- a/prettyprinter/pretty_stdlib.py
+++ b/prettyprinter/pretty_stdlib.py
@@ -7,10 +7,7 @@ from datetime import (
     date,
     time,
 )
-from enum import Enum
 from itertools import chain, dropwhile
-from uuid import UUID
-from types import MappingProxyType
 
 from .doc import (
     concat,
@@ -38,9 +35,9 @@ else:
     _PYTZ_INSTALLED = True
 
 
-@register_pretty(UUID)
+@register_pretty('uuid.UUID')
 def pretty_uuid(value, ctx):
-    return pretty_call(ctx, UUID, str(value))
+    return pretty_call(ctx, type(value), str(value))
 
 
 @register_pretty(datetime)
@@ -242,20 +239,20 @@ def pretty_timedelta(delta, ctx):
 
 @register_pretty(OrderedDict)
 def pretty_ordereddict(d, ctx):
-    return pretty_call(ctx, OrderedDict, [*d.items()])
+    return pretty_call(ctx, type(d), [*d.items()])
 
 
 @register_pretty(Counter)
 def pretty_counter(counter, ctx):
-    return pretty_call(ctx, Counter, dict(counter))
+    return pretty_call(ctx, type(counter), dict(counter))
 
 
-@register_pretty(Enum)
+@register_pretty('enum.Enum')
 def pretty_enum(value, ctx):
     cls = type(value)
     return classattr(cls, value.name)
 
 
-@register_pretty(MappingProxyType)
+@register_pretty('types.MappingProxyType')
 def pretty_mappingproxy(value, ctx):
-    return pretty_call(ctx, MappingProxyType, dict(value))
+    return pretty_call(ctx, type(value), dict(value))

--- a/prettyprinter/prettyprinter.py
+++ b/prettyprinter/prettyprinter.py
@@ -520,6 +520,7 @@ def register_pretty(type=None, predicate=None):
 
 def is_registered(
     type,
+    *,
     check_superclasses=False,
     check_deferred=True,
     register_deferred=True

--- a/prettyprinter/prettyprinter.py
+++ b/prettyprinter/prettyprinter.py
@@ -406,7 +406,6 @@ def pretty_python_value(value, ctx):
 
     value, comment, trailing_comment = unwrap_comments(value)
 
-    # Registers any deferred types
     is_registered(
         type(value),
         check_subclasses=True,

--- a/tests/test_prettyprinter.py
+++ b/tests/test_prettyprinter.py
@@ -486,3 +486,40 @@ def test_sort_dict_keys():
     }
     expected = """{'a': 2, 'x': 1}"""
     assert pformat(value, sort_dict_keys=True) == expected
+
+
+class TestDeferredType(dict):
+    pass
+
+
+def test_deferred_registration():
+    expected = 'Deferred type works.'
+
+    @register_pretty('tests.test_prettyprinter.TestDeferredType')
+    def pretty_testdeferredtype(value, ctx):
+        return expected
+
+    assert pformat(TestDeferredType()) == expected
+    assert pformat(TestDeferredType()) == expected
+
+
+class BaseTestDeferredType(dict):
+    pass
+
+
+class ConcreteTestDeferredType(BaseTestDeferredType):
+    pass
+
+
+def test_deferred_registration_subclass():
+    """Registering a printer for BaseTestDeferredType should be resolved
+    when using the subclass ConcreteTestDeferredType"""
+
+    expected = 'Deferred type works.'
+
+    @register_pretty('tests.test_prettyprinter.BaseTestDeferredType')
+    def pretty_testdeferredtype(value, ctx):
+        return expected
+
+    assert pformat(ConcreteTestDeferredType()) == expected
+    assert pformat(ConcreteTestDeferredType()) == expected

--- a/tests/test_prettyprinter.py
+++ b/tests/test_prettyprinter.py
@@ -495,12 +495,30 @@ class TestDeferredType(dict):
 def test_deferred_registration():
     expected = 'Deferred type works.'
 
+    assert not is_registered(TestDeferredType, register_deferred=False)
+
     @register_pretty('tests.test_prettyprinter.TestDeferredType')
     def pretty_testdeferredtype(value, ctx):
         return expected
 
+    assert not is_registered(
+        TestDeferredType,
+        check_deferred=False,
+        register_deferred=False
+    )
+    assert is_registered(
+        TestDeferredType,
+        register_deferred=False
+    )
+
     assert pformat(TestDeferredType()) == expected
-    assert pformat(TestDeferredType()) == expected
+
+    # Printer should have been moved to non-deferred registry
+    assert is_registered(
+        TestDeferredType,
+        check_deferred=False,
+        register_deferred=False
+    )
 
 
 class BaseTestDeferredType(dict):
@@ -521,5 +539,23 @@ def test_deferred_registration_subclass():
     def pretty_testdeferredtype(value, ctx):
         return expected
 
+    assert not is_registered(
+        ConcreteTestDeferredType,
+        check_subclasses=False,
+        register_deferred=False
+    )
+
+    assert is_registered(
+        ConcreteTestDeferredType,
+        check_subclasses=True,
+        register_deferred=False
+    )
+
     assert pformat(ConcreteTestDeferredType()) == expected
+    assert is_registered(
+        ConcreteTestDeferredType,
+        check_subclasses=True,
+        check_deferred=False,
+        register_deferred=False
+    )
     assert pformat(ConcreteTestDeferredType()) == expected

--- a/tests/test_prettyprinter.py
+++ b/tests/test_prettyprinter.py
@@ -426,14 +426,14 @@ def test_is_registered():
     assert not is_registered(MyClass)
 
     # object is not counted as a subclass
-    assert not is_registered(MyClass, check_subclasses=True)
+    assert not is_registered(MyClass, check_superclasses=True)
 
     @register_pretty(MyClass)
     def pretty_myclass(instance, ctx):
         return '...'
 
     assert is_registered(MyClass)
-    assert is_registered(MyClass, check_subclasses=True)
+    assert is_registered(MyClass, check_superclasses=True)
 
 
 def test_is_registered_subclass():
@@ -441,7 +441,7 @@ def test_is_registered_subclass():
         pass
 
     assert not is_registered(MyList)
-    assert is_registered(MyList, check_subclasses=True)
+    assert is_registered(MyList, check_superclasses=True)
 
 
 def test_pretty_repr():
@@ -541,20 +541,20 @@ def test_deferred_registration_subclass():
 
     assert not is_registered(
         ConcreteTestDeferredType,
-        check_subclasses=False,
+        check_superclasses=False,
         register_deferred=False
     )
 
     assert is_registered(
         ConcreteTestDeferredType,
-        check_subclasses=True,
+        check_superclasses=True,
         register_deferred=False
     )
 
     assert pformat(ConcreteTestDeferredType()) == expected
     assert is_registered(
         ConcreteTestDeferredType,
-        check_subclasses=True,
+        check_superclasses=True,
         check_deferred=False,
         register_deferred=False
     )

--- a/tests/test_stdlib_definitions.py
+++ b/tests/test_stdlib_definitions.py
@@ -1,0 +1,40 @@
+from collections import Counter, OrderedDict
+from enum import Enum
+from types import MappingProxyType
+from uuid import UUID
+
+from prettyprinter import pformat
+
+
+def test_counter():
+    value = Counter({'a': 1, 'b': 200})
+    expected = "collections.Counter({'a': 1, 'b': 200})"
+    assert pformat(value, width=999) == expected
+
+
+def test_ordereddict():
+    value = OrderedDict([('a', 1), ('b', 2)])
+    expected = "collections.OrderedDict([('a', 1), ('b', 2)])"
+    assert pformat(value, width=999) == expected
+
+
+def test_enum():
+    class TestEnum(Enum):
+        ONE = 1
+        TWO = 2
+
+    value = TestEnum.ONE
+    expected = 'tests.test_stdlib_definitions.test_enum.<locals>.TestEnum.ONE'
+    assert pformat(value) == expected
+
+
+def test_mappingproxytype():
+    value = MappingProxyType({'a': 1, 'b': 2})
+    expected = "mappingproxy({'a': 1, 'b': 2})"
+    assert pformat(value) == expected
+
+
+def test_uuid():
+    value = UUID('3ec21c4e-8125-478c-aa2c-c66de452c2eb')
+    expected = "uuid.UUID('3ec21c4e-8125-478c-aa2c-c66de452c2eb')"
+    assert pformat(value) == expected


### PR DESCRIPTION
Usage: instead of passing a type to `register_pretty`, pass the qualified path to the type as a string, which should match `type.__module__ + '.' + type.__qualname__`.

```python
from prettyprinter import register_pretty, pretty_call

@register_pretty('uuid.UUID')
def pretty_partial(value, ctx):
    return pretty_call(ctx, type(value), str(value))
```