### PR TITLE
Fix jupyter notebook usage: Replace stty with shutil.get_terminal_size

### DIFF
--- a/prettyprinter/extras/ipython.py
+++ b/prettyprinter/extras/ipython.py
@@ -4,6 +4,7 @@ from pygments.style import Style
 
 import IPython.lib.pretty
 from IPython.lib.pretty import RepresentationPrinter
+import shutil
 
 from .. import cpprint
 
@@ -41,12 +42,8 @@ def pygments_style_from_name_or_cls(name_or_cls, ishell):
 
 def install():
     ipy = get_ipython()  # noqa
-
-    try:
-        _rows, columns = os.popen('stty size', 'r').read().split()
-        columns = int(columns)
-    except:  # noqa
-        columns = 79
+    
+    columns = shutil.get_terminal_size((79, None)).columns
 
     class IPythonCompatPrinter:
         def __init__(self, stream, *args, **kwargs):

--- a/prettyprinter/extras/ipython.py
+++ b/prettyprinter/extras/ipython.py
@@ -7,6 +7,7 @@ from IPython.lib.pretty import RepresentationPrinter
 import shutil
 
 from .. import cpprint
+from ..utils import get_terminal_width
 
 OriginalRepresentationPrinter = RepresentationPrinter
 
@@ -43,7 +44,7 @@ def pygments_style_from_name_or_cls(name_or_cls, ishell):
 def install():
     ipy = get_ipython()  # noqa
     
-    columns = shutil.get_terminal_size((79, None)).columns
+    columns = get_terminal_width()
 
     class IPythonCompatPrinter:
         def __init__(self, stream, *args, **kwargs):

--- a/prettyprinter/extras/ipython.py
+++ b/prettyprinter/extras/ipython.py
@@ -4,7 +4,6 @@ from pygments.style import Style
 
 import IPython.lib.pretty
 from IPython.lib.pretty import RepresentationPrinter
-import shutil
 
 from .. import cpprint
 from ..utils import get_terminal_width

--- a/prettyprinter/utils.py
+++ b/prettyprinter/utils.py
@@ -1,5 +1,6 @@
 import os
 from itertools import islice
+import shutil
 
 
 def intersperse(x, ys):

--- a/prettyprinter/utils.py
+++ b/prettyprinter/utils.py
@@ -41,12 +41,7 @@ def identity(x):
 
 
 def get_terminal_width(default=79):
-    try:
-        _rows, columns = os.popen('stty size', 'r').read().split()
-        columns = int(columns)
-    except Exception:
-        return default
-    return columns
+    return shutil.get_terminal_size((default, None)).columns
 
 
 def take(n, iterable):


### PR DESCRIPTION
In an ipykernel (e.g. when in a jupyter notebook), `install_extras` emits a spurious error to stderr:
```py
$ jupyter console
>>> import prettyprinter; prettyprinter.install_extras(warn_on_error=False)
stty: 'standard input': Inappropriate ioctl for device
```

The problem appears to be the usage of the `stty` shell command:
```py
>>> import os; os.popen('stty size', 'r').read()
stty: 'standard input': Inappropriate ioctl for device
''
```

Replacing uses of `stty` with the builtin [`shutil.get_terminal_size()`](https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size) appears to avoid this:
```py
>>> import shutil; shutil.get_terminal_size()
os.terminal_size(columns=133, lines=75)
```