### PR TITLE
Fix invalid reST in HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -40,7 +40,7 @@ No breaking changes.
 No breaking changes.
 
 * Added Python 3.5 support
-* Added ``pretty_call_alt`` function that doesn't depend on ``dict``s maintaining insertion order
+* Added ``pretty_call_alt`` function that doesn't depend on ``dict`` maintaining insertion order
 * Fixed bug in ``set_default_config`` where most configuration values were not updated
 * Added ``get_default_config``
 


### PR DESCRIPTION
I think this is the reason the README isn't rendered on [PyPI](https://pypi.org/project/prettyprinter/).

I'm not sure how to keep the `s` there and be valid so I just removed it.