### PR TITLE
Only split Path prettyprints on "/", not on "-" or other nonword chars.

### DIFF
--- a/prettyprinter/pretty_stdlib.py
+++ b/prettyprinter/pretty_stdlib.py
@@ -31,6 +31,7 @@ from .prettyprinter import (
     register_pretty,
     pretty_call_alt,
     pretty_python_value,
+    pretty_str,
 )
 
 try:
@@ -339,6 +340,4 @@ def pretty_nodes(value, ctx):
     return pretty_call_alt(ctx, cls_name, kwargs=kwargs)
 
 
-@register_pretty('pathlib.PurePath')
-def pretty_pathlib(value, ctx):
-    return pretty_call_alt(ctx, type(value), args=(value.as_posix(),))
+register_pretty('pathlib.PurePath')(pretty_str)

--- a/prettyprinter/pretty_stdlib.py
+++ b/prettyprinter/pretty_stdlib.py
@@ -14,6 +14,7 @@ from datetime import (
     time,
 )
 from itertools import chain, dropwhile
+import re
 
 from .doc import (
     concat,
@@ -340,4 +341,14 @@ def pretty_nodes(value, ctx):
     return pretty_call_alt(ctx, cls_name, kwargs=kwargs)
 
 
-register_pretty('pathlib.PurePath')(pretty_str)
+pathstr_split_pattern = re.compile("(/+)")
+
+
+@register_pretty('pathlib.PurePath')
+def pretty_path(value, ctx):
+    strdoc = pretty_str(
+        value.as_posix(),
+        ctx,
+        split_pattern=pathstr_split_pattern
+    )
+    return build_fncall(ctx, type(value), argdocs=(strdoc, ))

--- a/prettyprinter/prettyprinter.py
+++ b/prettyprinter/prettyprinter.py
@@ -1701,20 +1701,11 @@ def str_to_lines(max_len, use_quote, s, pattern=None):
 
 @register_pretty(str)
 @register_pretty(bytes)
-def pretty_str(s, ctx):
+def pretty_str(s, ctx, split_pattern=None):
     # Subclasses of str/bytes
     # will be printed as StrSubclass('the actual string')
     constructor = type(s)
     is_native_type = constructor in (str, bytes)
-    pattern = None
-    # Support for pathlib is implemented here (but only registered in
-    # pretty_stdlib) so that it can use a custom pattern.
-    if (constructor.__module__, constructor.__name__) in [
-            ("pathlib", "PosixPath"), ("pathlib", "PurePosixPath"),
-            ("pathlib", "WindowsPath"), ("pathlib", "PureWindowsPath"),
-    ]:
-        pattern = re.compile("(/)")
-        s = s.as_posix()
 
     if ctx.depth_left == 0:
         return pretty_call_alt(ctx, constructor, args=(..., ))
@@ -1738,7 +1729,7 @@ def pretty_str(s, ctx):
             return build_fncall(ctx, constructor, argdocs=[flat_version])
 
         # multiline string
-        each_line_starts_on_col = indent + prettyprinter_indent
+        each_line_starts_on_col = indent
         each_line_ends_on_col = min(page_width, each_line_starts_on_col + ribbon_width)
 
         each_line_max_str_len = max(
@@ -1757,7 +1748,7 @@ def pretty_str(s, ctx):
             max_len=each_line_max_str_len,
             use_quote=use_quote,
             s=s,
-            pattern=pattern,
+            pattern=split_pattern,
         ))
 
         if len(lines) == 1:

--- a/tests/test_stdlib_definitions.py
+++ b/tests/test_stdlib_definitions.py
@@ -121,3 +121,28 @@ def test_purepath(typ, name, args, pathstr):
 pathlib.{}(
     {}
 )""".format(name, pathstr)
+
+
+@pytest.mark.parametrize('typ, name', [
+    pytest.param(
+        PosixPath, 'PosixPath',
+        marks=pytest.mark.skipif(os.name == 'nt', reason='POSIX only'),
+    ),
+    (PurePosixPath, 'PurePosixPath'),
+    pytest.param(
+        WindowsPath, 'WindowsPath',
+        marks=pytest.mark.skipif(os.name != 'nt', reason='Windows only'),
+    ),
+    (PureWindowsPath, 'PureWindowsPath'),
+])
+def test_purelongpath(typ, name):
+    as_str = "/a-b" * 10
+    path = typ(as_str)
+    assert pformat(path) == 'pathlib.{}({!r})'.format(name, as_str)
+    assert pformat(path, width=20) == """\
+pathlib.{}(
+    '/a-b/a-b/a-b/'
+    'a-b/a-b/a-b/'
+    'a-b/a-b/a-b/'
+    'a-b'
+)""".format(name)


### PR DESCRIPTION
This avoids formatting a long path that includes dashes as
```
pathlib.PosixPath(
    '/a-b/a-b/'
        'a-b/a-b/a-'
        'b/a-b/a-b/'
        'a-b/a-b/a-'
        'b'
```
preferring instead
```
pathlib.PosixPath(
    '/a-b/a-b/a-b/'
    'a-b/a-b/a-b/'
    'a-b/a-b/a-b/'
    'a-b'
)
```