### PR TITLE
Fix exponential runtime in highly nested data

### DIFF
--- a/prettyprinter/doctypes.py
+++ b/prettyprinter/doctypes.py
@@ -32,6 +32,9 @@ class Annotated(Doc):
     def __repr__(self):
         return 'Annotated({})'.format(repr(self.doc))
 
+    def normalize(self):
+        return Annotated(normalize_doc(self.doc), self.annotation)
+
 
 class Nil(Doc):
     def __repr__(self):
@@ -96,7 +99,7 @@ class Nest(Doc):
             return AlwaysBreak(
                 Nest(self.indent, inner_normalized.doc)
             )
-        return Nest(self.indent, normalize_doc(self.doc))
+        return Nest(self.indent, inner_normalized)
 
     def __repr__(self):
         return 'Nest({}, {})'.format(

--- a/tests/test_prettyprinter.py
+++ b/tests/test_prettyprinter.py
@@ -380,6 +380,22 @@ def test_gh_issue_25():
     )
 
 
+def test_gh_issue_28():
+    start = datetime.datetime.now()
+    pprint([])
+    end = datetime.datetime.now()
+    took = end - start
+
+    start2 = datetime.datetime.now()
+    pprint([[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]])
+    end2 = datetime.datetime.now()
+    took2 = end2 - start2
+
+    # Checks (with the simplest heuristic I could think of)
+    # that nesting does not introduce exponential runtime.
+    assert took2 < took * 100
+
+
 def test_large_data_performance():
     data = [
         {


### PR DESCRIPTION
- Fixes #28. The `normalize` method on the `Nest` doc was normalizing the subtree two times, so when it did that recursively on a highly nested structure...yikes.
- Adds another performance improvement: normalizing only the branch of FlatChoice that is accessed in the layout algorithm, saving us from normalizing the other branch (which is what has been happening)
- Normalizes Annotated Docs. Looks like I forgot to normalize the inner doc, though usually it's just a string doc and doesn't need normalizing