### PR TITLE
Pretty-print numpy scalars.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Comes packaged with the following pretty printer definitions, which you can enab
 - ``dataclasses`` - any new class you create will be pretty printed automatically
 - ``attrs`` - pretty prints any new class you create with ``attrs``
 - ``django`` - pretty prints your Models and QuerySets
-- ``numpy`` - explicitly marks the types of numpy scalars
+- ``numpy`` - pretty prints numpy scalars with explicit types
 - ``requests`` - pretty prints Requests, Responses, Sessions, and more from the ``requests`` library
 
 * Free software: MIT license

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,7 @@ Comes packaged with the following pretty printer definitions, which you can enab
 - ``dataclasses`` - any new class you create will be pretty printed automatically
 - ``attrs`` - pretty prints any new class you create with ``attrs``
 - ``django`` - pretty prints your Models and QuerySets
+- ``numpy`` - explicitly marks the types of numpy scalars
 - ``requests`` - pretty prints Requests, Responses, Sessions, and more from the ``requests`` library
 
 * Free software: MIT license

--- a/prettyprinter/__init__.py
+++ b/prettyprinter/__init__.py
@@ -28,9 +28,6 @@ from .render import default_render_to_stream
 # Registers standard library types
 # as a side effect
 import prettyprinter.pretty_stdlib  # noqa
-# Without this line, "prettyprinter.prettyprinter" ends up being a reference to
-# *this* module rather than to its prettyprinter submodule.
-del prettyprinter
 
 
 __all__ = [

--- a/prettyprinter/__init__.py
+++ b/prettyprinter/__init__.py
@@ -338,6 +338,7 @@ def install_extras(
         module.
     - ``'django'`` - automatically pretty prints Model and QuerySet subclasses defined in your
         Django apps.
+    - ``numpy`` - pretty prints numpy scalars with explicit types
     - ``'requests'`` - automatically pretty prints Requests, Responses, Sessions, etc.
     - ``'ipython'`` - makes prettyprinter the default printer in the IPython shell.
     - ``'python'`` - makes prettyprinter the default printer in the default Python shell.

--- a/prettyprinter/__init__.py
+++ b/prettyprinter/__init__.py
@@ -28,6 +28,9 @@ from .render import default_render_to_stream
 # Registers standard library types
 # as a side effect
 import prettyprinter.pretty_stdlib  # noqa
+# Without this line, "prettyprinter.prettyprinter" ends up being a reference to
+# *this* module rather than to its prettyprinter submodule.
+del prettyprinter
 
 
 __all__ = [
@@ -316,6 +319,7 @@ ALL_EXTRAS = frozenset([
     'django',
     'ipython',
     'ipython_repr_pretty',
+    'numpy',
     'python',
     'requests',
     'dataclasses',

--- a/prettyprinter/extras/numpy.py
+++ b/prettyprinter/extras/numpy.py
@@ -1,17 +1,22 @@
 from .. import prettyprinter
 from ..prettyprinter import (
-    register_pretty, pretty_singletons, pretty_int, pretty_float)
+    register_pretty,
+    pretty_bool,
+    pretty_int,
+    pretty_float
+)
 
 
 def install():
-    prettyprinter._NUMPY_EXTRA_INSTALLED = True
-    register_pretty("numpy.bool_")(pretty_singletons)
+    register_pretty("numpy.bool_")(pretty_bool)
+
     for name in [
-            "uint8", "uint16", "uint32", "uint64",
-            "int8", "int16", "int32", "int64",
+        "uint8", "uint16", "uint32", "uint64",
+        "int8", "int16", "int32", "int64",
     ]:
         register_pretty("numpy." + name)(pretty_int)
+
     for name in [
-            "float16", "float32", "float64", "float128",
+        "float16", "float32", "float64", "float128",
     ]:
         register_pretty("numpy." + name)(pretty_float)

--- a/prettyprinter/extras/numpy.py
+++ b/prettyprinter/extras/numpy.py
@@ -1,0 +1,17 @@
+from .. import prettyprinter
+from ..prettyprinter import (
+    register_pretty, pretty_singletons, pretty_int, pretty_float)
+
+
+def install():
+    prettyprinter._NUMPY_EXTRA_INSTALLED = True
+    register_pretty("numpy.bool_")(pretty_singletons)
+    for name in [
+            "uint8", "uint16", "uint32", "uint64",
+            "int8", "int16", "int32", "int64",
+    ]:
+        register_pretty("numpy." + name)(pretty_int)
+    for name in [
+            "float16", "float32", "float64", "float128",
+    ]:
+        register_pretty("numpy." + name)(pretty_float)

--- a/prettyprinter/prettyprinter.py
+++ b/prettyprinter/prettyprinter.py
@@ -1453,22 +1453,13 @@ def pretty_bool(value, ctx):
         argdocs=(doc, )
     )
 
-NoneType = type(None)
+
+NONE_DOC = annotate(Token.KEYWORD_CONSTANT, 'None')
 
 
-@register_pretty(NoneType)
+@register_pretty(type(None))
 def pretty_none(value, ctx):
-    constructor = type(value)
-
-    doc = annotate(Token.KEYWORD_CONSTANT, 'None')
-    if constructor is NoneType:
-        return doc
-
-    return build_fncall(
-        ctx,
-        general_identifier(constructor),
-        argdocs=(doc, )
-    )
+    return NONE_DOC
 
 
 SINGLE_QUOTE_TEXT = "'"

--- a/prettyprinter/prettyprinter.py
+++ b/prettyprinter/prettyprinter.py
@@ -1399,7 +1399,6 @@ def pretty_dict(d, ctx, trailing_comment=None):
 
 INF_FLOAT = float('inf')
 NEG_INF_FLOAT = float('-inf')
-_NUMPY_EXTRA_INSTALLED = False
 
 
 @register_pretty(float)
@@ -1419,12 +1418,7 @@ def pretty_float(value, ctx):
     doc = annotate(Token.NUMBER_FLOAT, repr(value))
     if constructor is float:
         return doc
-    # Depending on the architecture, either numpy.float32 or numpy.float64
-    # can inherit from float.
-    if not _NUMPY_EXTRA_INSTALLED and constructor.__module__ == "numpy":
-        import numpy
-        if constructor is numpy.float_:
-            return doc
+
     return build_fncall(ctx, general_identifier(constructor), argdocs=(doc, ))
 
 
@@ -1447,16 +1441,34 @@ def pretty_ellipsis(value, ctx):
 
 
 @register_pretty(bool)
-@register_pretty(type(None))
-@register_pretty("numpy.bool_")
-def pretty_singletons(value, ctx):
+def pretty_bool(value, ctx):
     constructor = type(value)
-    doc = annotate(Token.KEYWORD_CONSTANT, repr(value))
-    if (_NUMPY_EXTRA_INSTALLED
-            and get_deferred_key(constructor) == "numpy.bool_"):
-        return build_fncall(
-            ctx, general_identifier(constructor), argdocs=(doc, ))
-    return doc
+
+    doc = annotate(Token.KEYWORD_CONSTANT, 'True' if value else 'False')
+    if constructor is bool:
+        return doc
+    return build_fncall(
+        ctx,
+        general_identifier(constructor),
+        argdocs=(doc, )
+    )
+
+NoneType = type(None)
+
+
+@register_pretty(NoneType)
+def pretty_none(value, ctx):
+    constructor = type(value)
+
+    doc = annotate(Token.KEYWORD_CONSTANT, 'None')
+    if constructor is NoneType:
+        return doc
+
+    return build_fncall(
+        ctx,
+        general_identifier(constructor),
+        argdocs=(doc, )
+    )
 
 
 SINGLE_QUOTE_TEXT = "'"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -22,3 +22,4 @@ attrs==17.4.0
 Django==1.10.8
 pytest-django==3.4.7
 pytest-pythonpath==0.7.3
+numpy==1.16.1

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ test_requirements = [
     'tox-pyenv==1.1.0',
     'pytest-django==3.4.7',
     'pytest-pythonpath==0.7.3',
+    'numpy',
 ]
 
 setup(

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from prettyprinter import install_extras, pformat
+
+
+def test_numpy():
+    for tp in np.sctypes["uint"] + np.sctypes["int"] + np.sctypes["float"]:
+        np_scalar = tp(1)
+        py_scalar = np.array(1, tp).item()  # builtin int/float.
+        assert pformat(np_scalar) == pformat(py_scalar)
+    assert pformat(np.bool_(True)) == pformat(True)
+    install_extras(["numpy"])
+    for tp in (np.sctypes["uint"] + np.sctypes["int"] + np.sctypes["float"]
+               + [np.bool_]):
+        assert "(" in pformat(tp(1))

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,15 +1,32 @@
 import numpy as np
+import pytest
 
 from prettyprinter import install_extras, pformat
 
+install_extras(["numpy"])
 
-def test_numpy():
-    for tp in np.sctypes["uint"] + np.sctypes["int"] + np.sctypes["float"]:
-        np_scalar = tp(1)
-        py_scalar = np.array(1, tp).item()  # builtin int/float.
-        assert pformat(np_scalar) == pformat(py_scalar)
-    assert pformat(np.bool_(True)) == pformat(True)
-    install_extras(["numpy"])
-    for tp in (np.sctypes["uint"] + np.sctypes["int"] + np.sctypes["float"]
-               + [np.bool_]):
-        assert "(" in pformat(tp(1))
+
+@pytest.mark.parametrize('nptype', (
+    np.sctypes["uint"] +
+    np.sctypes["int"] +
+    np.sctypes["float"]
+))
+def test_numpy_numeric_types(nptype):
+    val = nptype(1)
+    py_val = val.item()
+
+    if type(py_val) in (int, float):
+        inner_printed = pformat(py_val)
+    else:
+        # numpy renders types such as float128,
+        # that are not representable in native Python
+        # types, with Python syntax
+        inner_printed = repr(py_val)
+
+    expected = "numpy.{}({})".format(nptype.__name__, inner_printed)
+    assert pformat(val) == expected
+
+
+def test_numpy_bool_type():
+    assert pformat(np.bool_(False)) == "numpy.bool_(False)"
+    assert pformat(np.bool_(True)) == "numpy.bool_(True)"


### PR DESCRIPTION
If the "numpy" extra is not installed, never add the "numpy.foo()"
constructor; if it is installed, always add it.

Closes #36.
The implementation is a bit of a mess :/