### PR TITLE
Fix various doc markup issues.

### DIFF
--- a/prettyprinter/__init__.py
+++ b/prettyprinter/__init__.py
@@ -338,16 +338,16 @@ def install_extras(
 
     - ``'attrs'`` - automatically pretty prints classes created using the ``attrs`` package.
     - ``'dataclasses'`` - automatically pretty prints classes created using the ``dataclasses``
-        module.
+      module.
     - ``'django'`` - automatically pretty prints Model and QuerySet subclasses defined in your
-        Django apps.
-    - ``numpy`` - pretty prints numpy scalars with explicit types
+      Django apps.
+    - ``'numpy'`` - pretty prints numpy scalars with explicit types
     - ``'requests'`` - automatically pretty prints Requests, Responses, Sessions, etc.
     - ``'ipython'`` - makes prettyprinter the default printer in the IPython shell.
     - ``'python'`` - makes prettyprinter the default printer in the default Python shell.
     - ``'ipython_repr_pretty'`` - automatically prints objects that define a ``_repr_pretty_``
-        method to integrate with
-        `IPython.lib.pretty <http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.pretty.html#extending>`_.
+      method to integrate with `IPython.lib.pretty
+      <http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.pretty.html#extending>`_.
 
     :param include: an iterable of strs representing the extras to include.
         All extras are included by default.


### PR DESCRIPTION
re: numpy extra: all other extras have quotes.

re: indents: the newline indentations cause spurious new paragraphs in the rendered docs at https://prettyprinter.readthedocs.io/en/latest/api_reference.html#prettyprinter.install_extras.