### PR TITLE
Improve prettyprinting of multidimensional numpy arrays.

### DIFF
--- a/prettyprinter/extras/numpy.py
+++ b/prettyprinter/extras/numpy.py
@@ -1,6 +1,7 @@
 import ast
 from distutils.version import LooseVersion
 
+from ..doctypes import Concat, HARDLINE
 from ..prettyprinter import (
     register_pretty,
     pretty_call_alt,
@@ -8,6 +9,11 @@ from ..prettyprinter import (
     pretty_int,
     pretty_float
 )
+
+
+class _ArrayWrapper:
+    def __init__(self, array):
+        self.array = array
 
 
 def pretty_ndarray(value, ctx):
@@ -19,7 +25,7 @@ def pretty_ndarray(value, ctx):
         # Masked arrays, in particular, require their own logic.
         return repr(value)
     from numpy.core import arrayprint
-    args = (value.tolist(),)
+    args = (_ArrayWrapper(value),)
     kwargs = []
     dtype = value.dtype
     # This logic is extracted from arrayprint._array_repr_implementation.
@@ -29,6 +35,21 @@ def pretty_ndarray(value, ctx):
         assert dtype_repr.startswith("dtype(") and dtype_repr.endswith(")")
         kwargs.append(("dtype", ast.literal_eval(dtype_repr[6:-1])))
     return pretty_call_alt(ctx, type(value), args, kwargs)
+
+
+def pretty_arraywrapper(value, ctx):
+    import numpy as np
+    # array2string correctly aligns the items of the array, without adding
+    # "array(" in the front or the dtype info (which we handle ourselves) in
+    # the back.
+    s = np.array2string(value.array, separator=", ")
+    lines = s.split("\n")
+    if len(lines) == 1:
+        return s
+    else:
+        interspersed = [HARDLINE] * 2 * len(lines)
+        interspersed[1::2] = lines
+        return Concat(interspersed)
 
 
 def install():
@@ -46,3 +67,5 @@ def install():
         register_pretty("numpy." + name)(pretty_float)
 
     register_pretty("numpy.ndarray")(pretty_ndarray)
+    register_pretty("prettyprinter.extras.numpy._ArrayWrapper")(
+        pretty_arraywrapper)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -32,13 +32,20 @@ def test_numpy_bool_type():
     assert pformat(np.bool_(True)) == "numpy.bool_(True)"
 
 
-def test_array():
+def test_array_dtype():
     assert pformat(np.array([0, 1])) == "numpy.ndarray([0, 1])"
-    assert pformat(np.array([0., 1.])) == "numpy.ndarray([0.0, 1.0])"
+    assert pformat(np.array([0., 1.])) == "numpy.ndarray([0., 1.])"
     assert pformat(np.array([0, 1], dtype=np.uint8)) == "numpy.ndarray([0, 1], dtype='uint8')"
     assert pformat(np.array(["a", "b"])) == "numpy.ndarray(['a', 'b'], dtype='<U1')"
     assert pformat(np.array([("a", 1)], [("field1", str), ("field2", int)])) \
         == "numpy.ndarray([('', 1)], dtype=[('field1', '<U'), ('field2', '<i8')])"
+
+
+def test_array_2d():
+    assert pformat(np.arange(4).reshape((2, 2))) == \
+        "numpy.ndarray(\n    [[0, 1],\n     [2, 3]])"
+    assert pformat(np.arange(4, dtype=np.uint8).reshape((2, 2))) == \
+        "numpy.ndarray(\n    [[0, 1],\n     [2, 3]], dtype='uint8')"
 
 
 def test_masked_array():


### PR DESCRIPTION
Items are now aligned by relying on numpy's own implementation.

Fixes most of #49.

It looks like I needed to insert hard linebreaks myself to get the right indentation.  One minor remaining problematic point is that the array's dtype gets printed on the same line as the array (if it fits) rather than on a separate line:
```
In [1]: np.arange(4, dtype=np.uint8).reshape((2, 2))                                                                 
Out[1]: 
numpy.ndarray(
    [[0, 1],
     [2, 3]], dtype='uint8')  # dtype='uint8' should go to the next line...
```
I guess the proper fix would be to move the dtype-handling logic from pretty_numpy to pretty_arraywrapper as well, but this would also require (I think?) duplicating some of the pretty_call logic, so it won't be for this PR...