### PR TITLE
On Py3.6+, pprint Counters in descending count order.

### DIFF
--- a/prettyprinter/pretty_stdlib.py
+++ b/prettyprinter/pretty_stdlib.py
@@ -296,7 +296,11 @@ def pretty_ordereddict(d, ctx):
 
 @register_pretty(Counter)
 def pretty_counter(counter, ctx):
-    return pretty_call_alt(ctx, type(counter), args=(dict(counter), ))
+    return pretty_call_alt(
+        ctx,
+        type(counter),
+        args=(dict(counter.most_common()), ),
+    )
 
 
 @register_pretty('enum.Enum')

--- a/tests/test_stdlib_definitions.py
+++ b/tests/test_stdlib_definitions.py
@@ -10,6 +10,7 @@ from collections import (
 from enum import Enum
 from functools import partial, partialmethod
 from pathlib import PosixPath, PurePosixPath, PureWindowsPath, WindowsPath
+import sys
 from types import MappingProxyType
 from uuid import UUID
 
@@ -22,6 +23,9 @@ def test_counter():
     value = Counter({'a': 1, 'b': 200})
     expected = "collections.Counter({'a': 1, 'b': 200})"
     assert pformat(value, width=999, sort_dict_keys=True) == expected
+    if sys.version_info >= (3, 6):
+        expected = "collections.Counter({'b': 200, 'a': 1})"
+        assert pformat(value, width=999, sort_dict_keys=False) == expected
 
 
 def test_ordereddict():


### PR DESCRIPTION
The Py3.6+-only part of #48.  (Let's punt the refactoring of pretty_dict to pretty_dict_from_pairs to another time...)