### PR TITLE
Improve prettyprinting of builtin bound methods.

### DIFF
--- a/prettyprinter/prettyprinter.py
+++ b/prettyprinter/prettyprinter.py
@@ -11,7 +11,6 @@ from traceback import format_exception
 from types import (
     FunctionType,
     BuiltinFunctionType,
-    BuiltinMethodType
 )
 from weakref import WeakKeyDictionary
 
@@ -219,6 +218,9 @@ def keyword_arg(s):
 def general_identifier(s):
     if callable(s):
         module, qualname = s.__module__, s.__qualname__
+        if module is None and hasattr(s, '__self__'):
+            # Builtin methods on builtin types.
+            module = type(s.__self__).__module__
 
         if module in IMPLICIT_MODULES:
             if module == 'builtins':
@@ -1042,19 +1044,12 @@ def pretty_function(fn, ctx):
     )
 
 
-@register_pretty(BuiltinMethodType)
-def pretty_builtin_method(method, ctx):
-    return comment(
-        general_identifier(method),
-        'built-in method'
-    )
-
-
-@register_pretty(BuiltinFunctionType)
+@register_pretty(BuiltinFunctionType)  # Also includes bound methods.
 def pretty_builtin_function(fn, ctx):
     return comment(
         general_identifier(fn),
-        'built-in function'
+        'built-in bound method' if hasattr(fn, '__self__')
+        else 'built-in function'
     )
 
 

--- a/tests/test_prettyprinter.py
+++ b/tests/test_prettyprinter.py
@@ -614,6 +614,10 @@ def test_list_subclass():
 ])"""
 
 
+def test_builtin_method():
+    assert pformat(int(1).to_bytes == "int.to_bytes  # built-in bound method")
+
+
 class TestDeferredType(dict):
     pass
 


### PR DESCRIPTION
Previously, a builtin bound method (e.g., `int(1).to_bytes`)
would pretty-print as `None.int.to_bytes # built-in function.`
This is because 1) the `pretty_builtin_method` registered on
BuiltinMethodType would never be called, as BuiltinMethodType is just
an alias for BuiltinFunctionType(!) (`types.BuiltinMethodType is
types.BuiltinFunctionType`), and builtin methods additionally don't set
their `__module__` (but we can retrieve it from `__self__`).

This PR prettyprints `int(1).to_bytes` as
```
int.to_bytes  # built-in bound method
```
it may be even nicer to have it as
```
int(1).to_bytes
```
(i.e. pretty-print the bound value as well) but that's more a general
problem for all bound methods (bound methods of classes written in
Python are not currently prettyprinted), so not in the scope of this PR.