### PR TITLE
Use $COLORFGBG to help decide whether to use a dark or light style

### DIFF
--- a/prettyprinter/color.py
+++ b/prettyprinter/color.py
@@ -127,7 +127,24 @@ class GitHubLightStyle(Style):
 default_dark_style = styles.get_style_by_name('monokai')
 default_light_style = GitHubLightStyle
 
-is_light_bg = bool(os.environ.get('PYPRETTYPRINTER_LIGHT_BACKGROUND', False))
+is_light_bg = None
+
+colorfgbg = os.environ.get('COLORFGBG', '')
+try:
+    fg, bg = map(int, colorfgbg.split(';', 1))
+    if bg > fg:
+        is_light_bg = True
+    if fg > bg:
+        is_light_bg = False
+except ValueError:
+    pass
+
+bg_override = os.environ.get('PYPRETTYPRINTER_LIGHT_BACKGROUND')
+if bg_override is not None:
+    is_light_bg = bool(bg_override)
+    if bg_override == '0' or bg_override.lower() == 'false':
+        is_light_bg = False
+
 default_style = default_light_style if is_light_bg else default_dark_style
 
 


### PR DESCRIPTION
Many terminals set `$COLORFGBG` to indicate the ANSI colors (or a best approximation) they are using as their foreground and background. For instance my iTerm2 sessions have it set to `0;15` (dark black on bright white) but in practice I have seen it set to `0;7`, `7;0`, and `15;0` by various terminal emulators. I propose looking at this variable to help decide which default style to use. `is_light_bg` starts off at `None` for unknown background color (note that this means we will still default to the dark style) and, if `$COLORFGBG` is present and parseable, becomes `True` or `False`.

If `$PYPRETTYPRINTER_LIGHT_BACKGROUND` is present it is allowed to override the detected setting based on `$COLORFGBG`.