### PR TITLE
Truncate numpy arrays with ndim >= 2 so that the total printed does not exceed max_seq_len

### DIFF
--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -46,3 +46,10 @@ def test_masked_array():
     # (they require their own algoithm, which is not implemented yet).
     array = np.ma.array([0, 1])
     assert pformat(array) == repr(array)
+
+
+def test_truncation():
+    array = np.zeros((11, 11, 11))
+    lines = pformat(array, max_seq_len=1000).split()
+    zeros = len(list(filter(lambda line: line.lstrip().startswith('0'), lines)))
+    assert zeros == 1000


### PR DESCRIPTION
When I tried to pretty-print an array I was working with, `np.eye(100)`, it took a large number of lines! It turns out `max_seq_len` is the maximum *subsequence* length and that ndarrays are being considered simply as nested lists. I altered this behavior: for ndarrays where `ndim` >= 2, a temporary `ctx_new.max_seq_len` is determined for each print, which is the maximum subsequence length `l` such that `np.prod(np.minimum(l, value.shape))` <= `ctx.max_seq_len`. It is determined through binary search (following the pseudocode [here](https://en.wikipedia.org/wiki/Binary_search_algorithm#Alternative_procedure)).