### PR TITLE
Use legacy for ZMQInteractiveShell instead of throwing AttributeError

### DIFF
--- a/prettyprinter/extras/ipython.py
+++ b/prettyprinter/extras/ipython.py
@@ -53,7 +53,7 @@ def install():
                 obj,
                 stream=self.stream,
                 style=pygments_style_from_name_or_cls(
-                    ipy.highlighting_style,
+                    getattr(ipy, "highlighting_style", "legacy"),
                     ishell=ipy
                 ),
                 width=columns,


### PR DESCRIPTION
highlighting_style is not available in ZMQInteractiveShell. Use "legacy" as is correct.